### PR TITLE
Parse unit test decimals using invariant culture.

### DIFF
--- a/test/ApacheOrcDotNet.OptimizedReader.Test/OrcReader_Test.cs
+++ b/test/ApacheOrcDotNet.OptimizedReader.Test/OrcReader_Test.cs
@@ -1,5 +1,6 @@
 ﻿using ApacheOrcDotNet.Protocol;
 using System;
+using System.Globalization;
 using System.Linq;
 using Xunit;
 
@@ -49,8 +50,8 @@ namespace ApacheOrcDotNet.OptimizedReader
             Assert.Equal(35, reader.GetFileColumnStatistics(2).IntStatistics.Maximum);
             Assert.Equal(311, reader.GetFileColumnStatistics(3).IntStatistics.Minimum);
             Assert.Equal(596293502, reader.GetFileColumnStatistics(3).IntStatistics.Maximum);
-            Assert.Equal(9.392m, decimal.Parse(reader.GetFileColumnStatistics(5).DecimalStatistics.Minimum));
-            Assert.Equal(72041.725554m, decimal.Parse(reader.GetFileColumnStatistics(5).DecimalStatistics.Maximum));
+            Assert.Equal(9.392m, decimal.Parse(reader.GetFileColumnStatistics(5).DecimalStatistics.Minimum, CultureInfo.InvariantCulture));
+            Assert.Equal(72041.725554m, decimal.Parse(reader.GetFileColumnStatistics(5).DecimalStatistics.Maximum, CultureInfo.InvariantCulture));
         }
 
         [Fact]
@@ -63,8 +64,8 @@ namespace ApacheOrcDotNet.OptimizedReader
             Assert.Equal(35, reader.GetStripeColumnStatistics(2, 0).IntStatistics.Maximum);
             Assert.Equal(311, reader.GetStripeColumnStatistics(3, 0).IntStatistics.Minimum);
             Assert.Equal(16690225, reader.GetStripeColumnStatistics(3, 0).IntStatistics.Maximum);
-            Assert.Equal(25200.063318m, decimal.Parse(reader.GetStripeColumnStatistics(5, 0).DecimalStatistics.Minimum));
-            Assert.Equal(71979.49409m, decimal.Parse(reader.GetStripeColumnStatistics(5, 0).DecimalStatistics.Maximum));
+            Assert.Equal(25200.063318m, decimal.Parse(reader.GetStripeColumnStatistics(5, 0).DecimalStatistics.Minimum, CultureInfo.InvariantCulture));
+            Assert.Equal(71979.49409m, decimal.Parse(reader.GetStripeColumnStatistics(5, 0).DecimalStatistics.Maximum, CultureInfo.InvariantCulture));
         }
 
         [Fact]

--- a/test/ApacheOrcDotNet.Test/ColumnTypes/DecimalReader_Test.cs
+++ b/test/ApacheOrcDotNet.Test/ColumnTypes/DecimalReader_Test.cs
@@ -1,10 +1,8 @@
 ﻿using ApacheOrcDotNet.ColumnTypes;
 using ApacheOrcDotNet.Stripes;
 using ApacheOrcDotNet.Test.TestHelpers;
-using System;
-using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace ApacheOrcDotNet.Test.ColumnTypes
@@ -36,7 +34,7 @@ namespace ApacheOrcDotNet.Test.ColumnTypes
 				{
 					var decimalPortion= 5 + i;
 					var wholePortion = -1000 + i;
-					expected = decimal.Parse($"{wholePortion}.{decimalPortion}");
+					expected = decimal.Parse($"{wholePortion}.{decimalPortion}", CultureInfo.InvariantCulture);
 				}
 				else if(i<4000)
 				{
@@ -46,7 +44,7 @@ namespace ApacheOrcDotNet.Test.ColumnTypes
 				{
 					var decimalPortion = (i - 4000) + 1;
 					var wholePortion = (i - 4000);
-					expected = decimal.Parse($"{wholePortion}.{decimalPortion}");
+					expected = decimal.Parse($"{wholePortion}.{decimalPortion}", CultureInfo.InvariantCulture);
 				}
 				Assert.Equal(expected, results[i]);
 			}


### PR DESCRIPTION
Update unit tests to use invariant culture when parsing decimals.